### PR TITLE
Add backend docs and config templates

### DIFF
--- a/namespace-notes/API_REFERENCE.md
+++ b/namespace-notes/API_REFERENCE.md
@@ -1,0 +1,34 @@
+# API Reference
+
+All endpoints are prefixed with `/api` as configured in `server/src/index.ts`.
+
+## POST `/api/documents/add`
+Add one or more documents to a workspace. Accepts `multipart/form-data` with a
+`files` field.
+- **Query Parameters**
+  - `namespaceId` (optional) – existing workspace identifier. If omitted and
+    `newWorkspace` is `true`, a new ID will be generated.
+  - `newWorkspace` (optional) – set to `true` to create a new workspace.
+- **Response**: JSON containing the resulting `namespaceId` and document
+  information.
+
+## DELETE `/api/documents/files/delete/:namespaceId/:documentId`
+Delete a document and its chunks from Pinecone and storage.
+- **Response**: `{ message: string }`
+
+## DELETE `/api/documents/workspace/:namespaceId`
+Remove an entire workspace including all files.
+- **Response**: `{ message: string }`
+
+## GET `/api/documents/files/:namespaceId`
+List files stored in a workspace.
+- **Response**: array of file metadata.
+
+## GET `/api/documents/files/:namespaceId/:documentId/*`
+Serve a specific uploaded file. When using local storage the file contents are
+sent directly; otherwise a redirect to the storage URL is returned.
+
+## POST `/api/context/fetch`
+Retrieve chat context for a series of messages.
+- **Request Body**: `{ namespaceId: string, messages: ChatMessage[] }`
+- **Response**: `{ query: string, context: string }`

--- a/namespace-notes/BACKEND_OVERVIEW.md
+++ b/namespace-notes/BACKEND_OVERVIEW.md
@@ -1,0 +1,35 @@
+# Backend Overview
+
+This document provides a quick reference for the server implementation located in
+`namespace-notes/server`.
+
+## Folder Structure
+
+- **controllers** – Express handlers for incoming requests.
+- **models** – Interactions with Pinecone and other services.
+- **routes** – Express route declarations mapping paths to controllers.
+- **utils** – Helper modules such as embedding logic and storage services.
+- **utils/storage** – Contains implementations of `ServerStorage` and
+  `SpacesStorage` for storing uploaded files.
+
+## Request Flow
+
+1. A client sends a request to a route defined in `routes`.
+2. The route calls a controller method which performs validation and orchestration.
+3. Controllers rely on models and utilities to interact with Pinecone and
+   to process files.
+4. Responses are returned to the client once work is complete.
+
+### Worker Threads
+
+File uploads are processed in a worker thread (`utils/workers/fileProcessorWorker`)
+to avoid blocking the main event loop. The worker parses the document,
+chunks the text and generates embeddings before the controller upserts them into
+Pinecone.
+
+## StorageService
+
+`utils/storage/storage.ts` exports a `storageService` instance which resolves to
+either `ServerStorage` (local filesystem) or `SpacesStorage` (DigitalOcean
+Spaces). This abstraction allows the application to switch storage backends by
+configuring environment variables.

--- a/namespace-notes/README.md
+++ b/namespace-notes/README.md
@@ -57,7 +57,7 @@ From the project root directory, run the following command.
 cd client && npm install
 ```
 
-Make sure you have populated the client `.env` with relevant keys.
+Copy `client/.env.dist` to `client/.env` and populate it with your keys.
 
 ```bash
 # You must first activate a Billing Account here: https://platform.openai.com/account/billing/overview
@@ -82,7 +82,7 @@ From the project root directory, run the following command.
 cd server && npm install
 ```
 
-Make sure you have populated the server `.env` with relevant keys.
+Copy `server/.env.dist` to `server/.env` and populate it with the required keys.
 
 ```bash
 PINECONE_API_KEY="your_pinecone_api_key_here"
@@ -118,6 +118,7 @@ The client uses local storage to store workspace information.
 **Backend Server**
 
 This project uses Node.js and Express to handle file uploads, validation checks, chunking, upsertion, context provision etc. Learn more about the implementation details below.
+For a high level description of the backend, see [BACKEND_OVERVIEW.md](./BACKEND_OVERVIEW.md). The API surface is summarised in [API_REFERENCE.md](./API_REFERENCE.md).
 
 ### Simple Multi-tenant RAG Methodology
 

--- a/namespace-notes/server/.env.dist
+++ b/namespace-notes/server/.env.dist
@@ -1,5 +1,8 @@
+# API key for connecting to Pinecone
 PINECONE_API_KEY="your_pinecone_api_key_here"
+# Name of the Pinecone index to use
 PINECONE_INDEX_NAME="your_pinecone_index_name_here"
+# API key used for embedding and chat completion requests
 OPENAI_API_KEY="your_openai_api_key_here"
 
 # Digital Ocean Spaces (OPTIONAL - for public file hosting)

--- a/namespace-notes/server/.prettierrc
+++ b/namespace-notes/server/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 80
+}

--- a/namespace-notes/server/eslint.config.js
+++ b/namespace-notes/server/eslint.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  env: {
+    node: true,
+    es2020: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 11,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  rules: {
+  },
+};

--- a/namespace-notes/server/package.json
+++ b/namespace-notes/server/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon --exec \"node --max-old-space-size=4096\" -r ts-node/register dist/index.js",
     "dev": "nodemon --exec \"node --max-old-space-size=4096\" -r ts-node/register src/index.ts",
-    "build": "npm install --include=dev && npx tsc --outDir dist"
+    "build": "npm install --include=dev && npx tsc --outDir dist",
+    "lint": "eslint \"src/**/*.{ts,js}\""
   },
   "keywords": [],
   "author": "",

--- a/namespace-notes/server/src/config.ts
+++ b/namespace-notes/server/src/config.ts
@@ -1,6 +1,13 @@
 import dotenv from "dotenv";
 dotenv.config();
 
+/**
+ * Application configuration values sourced from environment variables.
+ */
+
+/**
+ * Shape of the configuration object consumed throughout the server.
+ */
 interface Config {
   pineconeApiKey: string;
   pineconeIndexName: string;
@@ -8,6 +15,9 @@ interface Config {
   openAiOrganizationId: string;
 }
 
+/**
+ * Resolved configuration values.
+ */
 const config: Config = {
   pineconeApiKey: process.env.PINECONE_API_KEY || "",
   pineconeIndexName:

--- a/namespace-notes/server/src/controllers/contextController.ts
+++ b/namespace-notes/server/src/controllers/contextController.ts
@@ -1,5 +1,5 @@
 /**
- * Controller class for managing documents.
+ * Controller responsible for generating chat context from conversation messages.
  */
 import { Request, Response } from "express";
 import { createPrompt } from "../utils/promptCreation";
@@ -7,7 +7,7 @@ import { createPrompt } from "../utils/promptCreation";
 class ContextController {
 
   /**
-   * Constructs a new instance of DocumentsController.
+   * Constructs a new instance of ContextController.
    */
   constructor() {
 
@@ -15,10 +15,9 @@ class ContextController {
   }
 
   /**
-   * Adds a new document.
+   * Fetch context relevant to the supplied chat messages.
    * @param req - The request object.
    * @param res - The response object.
-   * @returns A promise that resolves to the added document.
    */
   async fetchContext(req: Request, res: Response) {
     try {

--- a/namespace-notes/server/src/index.ts
+++ b/namespace-notes/server/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Entry point for the Express server. Sets up middleware and routes and
+ * starts listening for incoming requests.
+ */
 // server/node/src/index.ts
 import fs from "fs";
 import path from "path";
@@ -9,7 +13,7 @@ import documentRoutes from "./routes/documentRoutes";
 import contextRoutes from "./routes/contextRoutes";
 var memwatch = require("@airbnb/node-memwatch");
 
-// Define the path for the uploads directory
+/** Path where uploaded files are stored. */
 const uploadsDir = path.join(__dirname, "..", "uploads");
 
 if (process.env.NODE_ENV === "production") {

--- a/namespace-notes/server/src/routes/contextRoutes.ts
+++ b/namespace-notes/server/src/routes/contextRoutes.ts
@@ -1,8 +1,15 @@
 import { Router } from 'express';
 import contextController from '../controllers/contextController';
 
+/**
+ * Routes related to fetching chat context for a workspace.
+ */
+
 const router = Router();
 
+/**
+ * POST /fetch - Return relevant context for a set of chat messages.
+ */
 router.post('/fetch', contextController.fetchContext);
 
 export default router;

--- a/namespace-notes/server/src/routes/documentRoutes.ts
+++ b/namespace-notes/server/src/routes/documentRoutes.ts
@@ -1,8 +1,15 @@
 import { Router } from "express";
 import documentController from "../controllers/documentController";
 
+/**
+ * Routes for uploading and managing workspace documents.
+ */
+
 const router = Router();
 
+/**
+ * POST /add - Upload one or more documents.
+ */
 router.post("/add", (req, res) => {
   const { namespaceId } = req.query;
 
@@ -13,14 +20,25 @@ router.post("/add", (req, res) => {
   documentController.addDocuments(req, res);
 });
 
+/**
+ * DELETE /files/delete/:namespaceId/:documentId - Remove a specific document.
+ */
 router.delete(
   "/files/delete/:namespaceId/:documentId",
   documentController.deleteDocument
 );
 
+/**
+ * DELETE /workspace/:namespaceId - Remove an entire workspace.
+ */
 router.delete("/workspace/:namespaceId", documentController.deleteWorkspace);
 
+/** GET /files/:namespaceId - List files in a workspace. */
 router.get("/files/:namespaceId", documentController.listFilesInNamespace);
-router.get("/files/:namespaceId/:documentId/(*)",  documentController.serveDocument);
+/** GET /files/:namespaceId/:documentId/(*) - Serve a stored file. */
+router.get(
+  "/files/:namespaceId/:documentId/(*)",
+  documentController.serveDocument
+);
 
 export default router;

--- a/namespace-notes/server/src/utils/context.ts
+++ b/namespace-notes/server/src/utils/context.ts
@@ -2,6 +2,16 @@ import { ScoredPineconeRecord } from "@pinecone-database/pinecone";
 import { Metadata, getMatchesFromEmbeddings } from "./pinecone";
 import { embedChunks } from "./embeddings";
 
+/**
+ * Retrieve matching context records for a chat message.
+ *
+ * @param message - The user message to embed.
+ * @param namespace - Namespace in Pinecone to search.
+ * @param maxCharacters - Maximum length of returned context string.
+ * @param minScore - Minimum similarity score to consider a match.
+ * @param getOnlyText - When true returns concatenated text rather than match objects.
+ * @returns Concatenated context or full match objects depending on `getOnlyText`.
+ */
 // The function `getContext` is used to retrieve the context of a given message
 export const getContext = async (
   message: string,

--- a/namespace-notes/server/src/utils/multer.ts
+++ b/namespace-notes/server/src/utils/multer.ts
@@ -2,7 +2,15 @@ import multer from 'multer';
 import path from 'path';
 import { Request } from 'express';
 
-const fileFilter = (req: Request, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
+/**
+ * Validate uploaded files, allowing only PDF documents.
+ */
+
+const fileFilter = (
+  req: Request,
+  file: Express.Multer.File,
+  cb: multer.FileFilterCallback,
+) => {
   const allowedExtensions = ['.pdf'];
   const extension = path.extname(file.originalname).toLowerCase();
   if (allowedExtensions.includes(extension)) {
@@ -21,6 +29,9 @@ const storage = multer.diskStorage({
   },
 });
 
+/**
+ * Multer instance configured for PDF uploads up to 25MB.
+ */
 export const upload = multer({
   storage: storage,
   fileFilter: fileFilter,

--- a/namespace-notes/server/src/utils/pinecone.ts
+++ b/namespace-notes/server/src/utils/pinecone.ts
@@ -11,6 +11,14 @@ export type Metadata = {
 };
 
 // Used to retrieve matches for the given embeddings
+/**
+ * Query Pinecone and return matching records.
+ *
+ * @param embeddings - Embedding vector to search with.
+ * @param topK - Number of matches to return.
+ * @param namespace - Namespace to search within.
+ * @returns Matching Pinecone records with metadata and similarity scores.
+ */
 const getMatchesFromEmbeddings = async (
   embeddings: number[],
   topK: number,

--- a/namespace-notes/server/src/utils/promptCreation.ts
+++ b/namespace-notes/server/src/utils/promptCreation.ts
@@ -1,5 +1,13 @@
 import { getContext } from "./context";
 
+/**
+ * Build the system prompt for the chat model using conversation messages and
+ * retrieved context.
+ *
+ * @param messages - Array of chat messages.
+ * @param namespaceId - Workspace namespace to fetch context from.
+ * @returns Object containing the prompt array.
+ */
 export async function createPrompt(messages: any[], namespaceId: string) {
   try {
     // Get the last message

--- a/namespace-notes/server/src/utils/storage/serverStorage.ts
+++ b/namespace-notes/server/src/utils/storage/serverStorage.ts
@@ -3,9 +3,15 @@ import fs from "fs";
 import path from "path";
 import { FileDetail, StorageService } from "./storage";
 
+/**
+ * Local filesystem-based implementation of {@link StorageService}.
+ */
 export class ServerStorage implements StorageService {
   private readonly uploadDir = "uploads";
 
+  /**
+   * Save an uploaded file to the server's local filesystem.
+   */
   async saveFile(file: Express.Multer.File, fileKey: string): Promise<void> {
     const [namespaceId, documentId, ...rest] = fileKey.split("/");
     const fileName = rest.join("/");
@@ -23,12 +29,18 @@ export class ServerStorage implements StorageService {
     await fs.promises.rename(file.path, destinationPath);
   }
 
+  /**
+   * Construct the public URL for a stored file.
+   */
   constructFileUrl(fileKey: string): string {
     const domain =
       process.env.SERVER_URL || `http://localhost:${process.env.PORT || 4001}`;
     return `${domain}/api/documents/files/${fileKey}`;
   }
 
+  /**
+   * Resolve the absolute path to a stored file.
+   */
   async getFilePath(fileKey: string): Promise<string> {
     const filePath = path.join(this.uploadDir, fileKey);
     const files = await fs.promises.readdir(filePath);
@@ -36,6 +48,9 @@ export class ServerStorage implements StorageService {
     return path.join(filePath, firstFile);
   }
 
+  /**
+   * Remove all files for a namespace from disk.
+   */
   async deleteWorkspaceFiles(namespaceId: string): Promise<void> {
     const namespaceDirectory = path.join(this.uploadDir, namespaceId);
     if (fs.existsSync(namespaceDirectory)) {
@@ -43,6 +58,9 @@ export class ServerStorage implements StorageService {
     }
   }
 
+  /**
+   * Delete a specific document from a namespace.
+   */
   async deleteFileFromWorkspace(
     namespaceId: string,
     documentId: string
@@ -62,6 +80,9 @@ export class ServerStorage implements StorageService {
     }
   }
 
+  /**
+   * List all files stored for a namespace.
+   */
   async listFilesInNamespace(namespaceId: string): Promise<FileDetail[]> {
     const namespacePath = path.join(this.uploadDir, namespaceId);
     try {

--- a/namespace-notes/server/src/utils/storage/spacesStorage.ts
+++ b/namespace-notes/server/src/utils/storage/spacesStorage.ts
@@ -5,6 +5,9 @@ import { Upload } from "@aws-sdk/lib-storage";
 import { S3, ObjectCannedACL } from "@aws-sdk/client-s3";
 import { FileDetail, StorageService } from "./storage";
 
+/**
+ * DigitalOcean Spaces implementation of {@link StorageService}.
+ */
 const spacesEndpoint = `https://nyc3.digitaloceanspaces.com`;
 
 const s3 = new S3({
@@ -17,6 +20,9 @@ const s3 = new S3({
 });
 
 export class SpacesStorage implements StorageService {
+  /**
+   * Upload a file to DigitalOcean Spaces.
+   */
   async saveFile(file: Express.Multer.File, fileKey: string): Promise<void> {
     const fileStream = fs.createReadStream(file.path, { autoClose: true });
 
@@ -49,6 +55,9 @@ export class SpacesStorage implements StorageService {
     }
   }
 
+  /**
+   * Delete all files for a given document from Spaces.
+   */
   async deleteFileFromWorkspace(
     namespaceId: string,
     documentId: string
@@ -76,14 +85,23 @@ export class SpacesStorage implements StorageService {
     }
   }
 
+  /**
+   * `getFilePath` is unused for Spaces storage.
+   */
   async getFilePath(fileKey: string): Promise<string> {
     throw new Error("Not necessary for Spaces storage");
   }
 
+  /**
+   * Create a public URL for a stored file.
+   */
   constructFileUrl(fileKey: string): string {
     return `https://${process.env.DO_SPACES_BUCKET_NAME}.nyc3.digitaloceanspaces.com/${fileKey}`;
   }
 
+  /**
+   * Delete all files under a namespace prefix.
+   */
   async deleteWorkspaceFiles(namespaceId: string): Promise<void> {
     const filePrefix = `${namespaceId}/`;
     const listParams = {
@@ -126,12 +144,18 @@ export class SpacesStorage implements StorageService {
     }
   }
 
+  /**
+   * List all files for a namespace by recursively fetching objects.
+   */
   async listFilesInNamespace(namespaceId: string): Promise<FileDetail[]> {
     const bucket = process.env.DO_SPACES_BUCKET_NAME!;
     const prefix = `${namespaceId}/`;
     return this.listFilesRecursive(prefix, bucket);
   }
 
+  /**
+   * Helper to recursively list objects inside a prefix.
+   */
   private async listFilesRecursive(
     currentPrefix: string,
     bucket: string

--- a/namespace-notes/server/src/utils/storage/storage.ts
+++ b/namespace-notes/server/src/utils/storage/storage.ts
@@ -1,11 +1,15 @@
 // storage.ts
 
+/** Details about a stored file. */
 export interface FileDetail {
   documentId: string;
   name: string;
   url: string;
 }
 
+/**
+ * Generic file storage interface used by the application.
+ */
 export interface StorageService {
   saveFile(file: Express.Multer.File, fileKey: string): Promise<void>;
   constructFileUrl(fileKey: string): string;
@@ -24,6 +28,7 @@ import { SpacesStorage } from "./spacesStorage";
 const useSpaces =
   process.env.DO_SPACES_ACCESS_KEY_ID &&
   process.env.DO_SPACES_SECRET_ACCESS_KEY;
+/** Chosen implementation of {@link StorageService} based on environment vars. */
 export const storageService: StorageService = useSpaces
   ? new SpacesStorage()
   : new ServerStorage();

--- a/namespace-notes/server/src/utils/workers/fileProcessorWorker.ts
+++ b/namespace-notes/server/src/utils/workers/fileProcessorWorker.ts
@@ -1,6 +1,15 @@
 import { parentPort, workerData } from "worker_threads";
 import { chunkAndEmbedFile, processFile } from "../documentProcessor";
 
+/**
+ * Worker thread entry used to process an uploaded file without blocking the
+ * main event loop. It reads the file, chunks and embeds it then returns the
+ * resulting document back to the parent thread.
+ */
+
+/**
+ * Perform document processing and send the result back to the parent.
+ */
 async function processFileWorker() {
   const { fileData, fileType, fileName, documentId, documentUrl } = workerData;
   try {


### PR DESCRIPTION
## Summary
- document backend architecture in new BACKEND_OVERVIEW.md
- provide short API reference
- clarify env setup in README
- add eslint and prettier config files
- add lint script in server package.json
- document variables in server `.env.dist`
- add comprehensive JSDoc comments across the backend

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: missing dependencies)*