### PR TITLE
Add auth middleware for namespace-notes server

### DIFF
--- a/namespace-notes/server/@types/express/index.d.ts
+++ b/namespace-notes/server/@types/express/index.d.ts
@@ -1,0 +1,9 @@
+declare namespace Express {
+  interface Request {
+    user?: {
+      id: string;
+      email: string;
+      [key: string]: any;
+    };
+  }
+}

--- a/namespace-notes/server/package.json
+++ b/namespace-notes/server/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.6.8",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",
     "mime": "^4.0.1",

--- a/namespace-notes/server/src/index.ts
+++ b/namespace-notes/server/src/index.ts
@@ -7,10 +7,12 @@ import fs from "fs";
 import path from "path";
 import express from "express";
 import bodyParser from "body-parser";
+import cookieParser from "cookie-parser";
 import cors from "cors";
 import dotenv from "dotenv";
 import documentRoutes from "./routes/documentRoutes";
 import contextRoutes from "./routes/contextRoutes";
+import authMiddleware from "./middleware/auth";
 var memwatch = require("@airbnb/node-memwatch");
 
 /** Path where uploaded files are stored. */
@@ -36,6 +38,8 @@ const PORT = process.env.PORT || 4001;
 
 app.use(cors());
 app.use(bodyParser.json());
+app.use(cookieParser());
+app.use(authMiddleware);
 
 app.use("/api/documents", documentRoutes);
 app.use("/api/context", contextRoutes);

--- a/namespace-notes/server/src/middleware/auth.ts
+++ b/namespace-notes/server/src/middleware/auth.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+import axios from 'axios';
+
+export interface LatenodeUser {
+  id: string;
+  email: string;
+  [key: string]: any;
+}
+
+/**
+ * Authentication middleware verifying AUTH_TOKEN cookie against latenode API.
+ */
+export default async function authMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const token = req.cookies?.AUTH_TOKEN;
+  if (!token) {
+    return res.status(401).json({ message: 'You are not authorized' });
+  }
+
+  try {
+    const response = await axios.get(
+      'https://api.latenode.com/users/v1/user/info',
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+    const { data } = response;
+    if (!data?.success || !data.data?.id || !data.data?.email) {
+      return res.status(401).json({ message: 'You are not authorized' });
+    }
+    (req as Request & { user?: LatenodeUser }).user = data.data;
+    return next();
+  } catch (error) {
+    return res.status(401).json({ message: 'You are not authorized' });
+  }
+}


### PR DESCRIPTION
## Summary
- add auth middleware to validate AUTH_TOKEN cookie
- register cookie-parser and auth middleware in the express app
- extend Express Request type with `user`
- include cookie-parser in dependencies

## Testing
- `npm run lint` *(fails: all files matching glob ignored)*
- `npm run build` *(fails: request to https://registry.npmjs.org/cookie-parser failed)*
