### PR TITLE
Add auth endpoint and workspace ID updates

### DIFF
--- a/namespace-notes/API_REFERENCE.md
+++ b/namespace-notes/API_REFERENCE.md
@@ -6,29 +6,29 @@ All endpoints are prefixed with `/api` as configured in `server/src/index.ts`.
 Add one or more documents to a workspace. Accepts `multipart/form-data` with a
 `files` field.
 - **Query Parameters**
-  - `namespaceId` (optional) – existing workspace identifier. If omitted and
+  - `workspaceId` (optional) – existing workspace identifier. If omitted and
     `newWorkspace` is `true`, a new ID will be generated.
   - `newWorkspace` (optional) – set to `true` to create a new workspace.
-- **Response**: JSON containing the resulting `namespaceId` and document
+  - **Response**: JSON containing the resulting `workspaceId` and document
   information.
 
-## DELETE `/api/documents/files/delete/:namespaceId/:documentId`
+## DELETE `/api/documents/files/delete/:workspaceId/:documentId`
 Delete a document and its chunks from Pinecone and storage.
 - **Response**: `{ message: string }`
 
-## DELETE `/api/documents/workspace/:namespaceId`
+## DELETE `/api/documents/workspace/:workspaceId`
 Remove an entire workspace including all files.
 - **Response**: `{ message: string }`
 
-## GET `/api/documents/files/:namespaceId`
+## GET `/api/documents/files/:workspaceId`
 List files stored in a workspace.
 - **Response**: array of file metadata.
 
-## GET `/api/documents/files/:namespaceId/:documentId/*`
+## GET `/api/documents/files/:workspaceId/:documentId/*`
 Serve a specific uploaded file. When using local storage the file contents are
 sent directly; otherwise a redirect to the storage URL is returned.
 
 ## POST `/api/context/fetch`
 Retrieve chat context for a series of messages.
-- **Request Body**: `{ namespaceId: string, messages: ChatMessage[] }`
+  - **Request Body**: `{ workspaceId: string, messages: ChatMessage[] }`
 - **Response**: `{ query: string, context: string }`

--- a/namespace-notes/README.md
+++ b/namespace-notes/README.md
@@ -126,7 +126,7 @@ This project uses a basic RAG architecture that achieves multitenancy through th
 
 **Tenant Isolation**
 
-We use namespaces as the mechanism to separate context between worksapces. When we add documents, we check for a namespaceId or generate a new id if the workspace is being created.
+We use namespaces as the mechanism to separate context between workspaces. When we add documents, we check for a workspaceId or generate a new id if the workspace is being created. The server prefixes this id based on the authenticated user.
 
 ```typescript
 /**
@@ -137,7 +137,7 @@ We use namespaces as the mechanism to separate context between worksapces. When 
 */
 async addDocuments(req: Request, res: Response) {
   // This is effectively the ID of the workspace / tenant
-  let namespaceId = req.body.namespaceId;
+  let workspaceId = req.body.workspaceId;
   //...
 ```
 

--- a/namespace-notes/client/src/app/(workspace)/layout.tsx
+++ b/namespace-notes/client/src/app/(workspace)/layout.tsx
@@ -2,14 +2,17 @@
 
 import Sidenav from '@/components/ui/sidenav';
 import { WorkspaceChatProvider } from '../../lib/hooks/workspace-chat-context';
+import { AuthProvider } from '../../lib/hooks/auth-context';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <WorkspaceChatProvider>
-      <div className="flex h-screen bg-white">
-        <Sidenav />
-        <main className="flex-1 p-4 overflow-auto ">{children}</main>
-      </div>
-    </WorkspaceChatProvider>
+    <AuthProvider>
+      <WorkspaceChatProvider>
+        <div className="flex h-screen bg-white">
+          <Sidenav />
+          <main className="flex-1 p-4 overflow-auto ">{children}</main>
+        </div>
+      </WorkspaceChatProvider>
+    </AuthProvider>
   );
 }

--- a/namespace-notes/client/src/app/(workspace)/workspace/[slug]/(chat)/Chat.tsx
+++ b/namespace-notes/client/src/app/(workspace)/workspace/[slug]/(chat)/Chat.tsx
@@ -32,11 +32,16 @@ export default function ChatPage() {
 
     const handleDeleteWorkspace = async (workspaceId: string) => {
         setIsDeleting(true);
-        console.log(`/api/files/?namespaceId=${workspaceId}`);
+        console.log(`/api/files/?workspaceId=${workspaceId}`);
         try {
-            const response = await fetch(`/api/files/?namespaceId=${workspaceId}`, {
+            const response = await fetch(`/api/files/?workspaceId=${workspaceId}`, {
                 method: 'DELETE',
             });
+            if (response.status === 401) {
+                alert('You are not authorized');
+                setIsDeleting(false);
+                return;
+            }
             const responseData = await response.json();
             removeWorkspace(workspaceId);
             console.log(responseData.message);

--- a/namespace-notes/client/src/app/(workspace)/workspace/new/page.tsx
+++ b/namespace-notes/client/src/app/(workspace)/workspace/new/page.tsx
@@ -50,14 +50,14 @@ export default function NewPage() {
       console.log("Files uploaded successfully:", data);
 
       const newWorkspace: Workspace = {
-        id: data.namespaceId,
+        id: data.workspaceId,
         name: title,
         createdAt: Date.now(),
         fileUrls: [],
       };
       addWorkspace(newWorkspace);
 
-      router.push(`/workspace/${data.namespaceId}`);
+      router.push(`/workspace/${data.workspaceId}`);
     } catch (error) {
       console.error("Error uploading files:", error);
       alert(`Failed to upload files. Please try again. ${error}`);

--- a/namespace-notes/client/src/app/api/chat/route.ts
+++ b/namespace-notes/client/src/app/api/chat/route.ts
@@ -11,17 +11,21 @@ export const runtime = "edge";
  * @throws An error if the expected prompt structure is not present in the server response.
  */
 export async function POST(req: Request) {
-  const { messages, namespaceId } = await req.json();
+  const { messages, workspaceId } = await req.json();
   const response = await fetch(`${process.env.SERVER_URL}/api/context/fetch`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      namespaceId: namespaceId,
+      workspaceId: workspaceId,
       messages: messages,
     }),
   });
+
+  if (response.status === 401) {
+    return new Response("Unauthorized", { status: 401 });
+  }
 
   const { context } = await response.json();
 

--- a/namespace-notes/client/src/app/api/files/file-upload-util.ts
+++ b/namespace-notes/client/src/app/api/files/file-upload-util.ts
@@ -7,11 +7,15 @@ export async function uploadFiles(data: FormData) {
         body: data,
       }
     );
+    if (response.status === 401) {
+      alert('You are not authorized');
+      throw new Error('Unauthorized');
+    }
 
     if (response.ok) {
       const responseData = await response.json();
       console.log("Files uploaded successfully:", responseData);
-      return { namespaceId: responseData.namespaceId };
+      return { workspaceId: responseData.workspaceId };
     } else {
       throw new Error("Failed to upload files, " + response.statusText);
     }

--- a/namespace-notes/client/src/app/api/files/route.ts
+++ b/namespace-notes/client/src/app/api/files/route.ts
@@ -16,18 +16,21 @@ export const maxDuration = 600
  * @param res - The response object.
  */
 export async function GET(request: Request) {
-  const namespaceId = new URL(request.url).searchParams.get("namespaceId");
+  const workspaceId = new URL(request.url).searchParams.get("workspaceId");
 
-  console.log("GET request to fetch files for namespace:", namespaceId);
+  console.log("GET request to fetch files for workspace:", workspaceId);
 
-  if (typeof namespaceId !== "string") {
-    throw new Error("Invalid or missing namespace ID in request URL");
+  if (typeof workspaceId !== "string") {
+    throw new Error("Invalid or missing workspace ID in request URL");
   }
 
   try {
     // Ensure the SERVER_URL is correctly configured in your environment
-    const url = `${process.env.SERVER_URL}/api/documents/files/${namespaceId}`;
+    const url = `${process.env.SERVER_URL}/api/documents/files/${workspaceId}`;
     const response = await fetch(url, { method: "GET" });
+    if (response.status === 401) {
+      return new Response("Unauthorized", { status: 401 });
+    }
     const data = await response.json();
 
     if (!response.ok) {
@@ -71,12 +74,15 @@ export async function POST(req: Request) {
         body: formData,
       }
     );
+    if (response.status === 401) {
+      return new Response("Unauthorized", { status: 401 });
+    }
 
     if (response.ok) {
       const responseData = await response.json();
       console.log("Files uploaded successfully:", responseData);
       return new Response(
-        JSON.stringify({ namespaceId: responseData.namespaceId }),
+        JSON.stringify({ workspaceId: responseData.workspaceId }),
         { status: 200 }
       );
     } else {
@@ -97,10 +103,10 @@ export async function POST(req: Request) {
  */
 export async function DELETE(request: Request) {
   const documentId = new URL(request.url).searchParams.get("documentId");
-  const namespaceId = new URL(request.url).searchParams.get("namespaceId");
+  const workspaceId = new URL(request.url).searchParams.get("workspaceId");
 
-  if (typeof namespaceId !== "string") {
-    throw new Error("Invalid or missing namespace ID in request URL");
+  if (typeof workspaceId !== "string") {
+    throw new Error("Invalid or missing workspace ID in request URL");
   }
 
   try {
@@ -109,15 +115,18 @@ export async function DELETE(request: Request) {
 
     if (typeof documentId === "string") {
       // Delete a specific document
-      url = `${process.env.SERVER_URL}/api/documents/files/delete/${namespaceId}/${documentId}`;
+      url = `${process.env.SERVER_URL}/api/documents/files/delete/${workspaceId}/${documentId}`;
       message = "File deleted successfully";
     } else {
       // Delete the entire workspace/namespace
-      url = `${process.env.SERVER_URL}/api/documents/workspace/${namespaceId}`;
+      url = `${process.env.SERVER_URL}/api/documents/workspace/${workspaceId}`;
       message = "Workspace deleted successfully";
     }
 
     const response = await fetch(url, { method: "DELETE" });
+    if (response.status === 401) {
+      return new Response("Unauthorized", { status: 401 });
+    }
     const data = await response.json();
 
     if (!response.ok) {

--- a/namespace-notes/client/src/components/chat/chat.tsx
+++ b/namespace-notes/client/src/components/chat/chat.tsx
@@ -14,7 +14,11 @@ import { FetchedFile } from '@/app/api/files/route';
 
 const fetchFileUrls = async (workspaceId: string) => {
   try {
-    const response = await fetch(`/api/files/?namespaceId=${workspaceId}`);
+    const response = await fetch(`/api/files/?workspaceId=${workspaceId}`);
+    if (response.status === 401) {
+      alert('You are not authorized');
+      return [];
+    }
     if (!response.ok) {
       throw new Error('Failed to fetch file URLs');
     }
@@ -28,7 +32,8 @@ const fetchFileUrls = async (workspaceId: string) => {
 
 export default function Chat({ workspace }: { workspace: Workspace }) {
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    body: { namespaceId: workspace.id },
+    body: { workspaceId: workspace.id },
+    onResponse: (res) => { if (res.status === 401) { alert('You are not authorized'); } return res; }
   });
 
   const [files, setFiles] = useState<FetchedFile[]>([]);
@@ -66,11 +71,15 @@ export default function Chat({ workspace }: { workspace: Workspace }) {
   }, [shouldSubmit]);
 
   const handleDeleteFile = async (documentId: string) => {
-    console.log(`/api/files/?documentId=${documentId}&namespaceId=${workspace.id}`);
+    console.log(`/api/files/?documentId=${documentId}&workspaceId=${workspace.id}`);
     try {
-      const response = await fetch(`/api/files/?documentId=${documentId}&namespaceId=${workspace.id}`, {
+      const response = await fetch(`/api/files/?documentId=${documentId}&workspaceId=${workspace.id}`, {
         method: 'DELETE',
       });
+      if (response.status === 401) {
+        alert('You are not authorized');
+        return;
+      }
       const responseData = await response.json();
       console.log(responseData.message);
       fetchFiles();
@@ -226,7 +235,7 @@ export default function Chat({ workspace }: { workspace: Workspace }) {
 /**
  * Extracts the documentId from a given file URL.
  * Assumes the URL pattern is: 
- * https://domain/[namespaceId]/[documentId]/[filename]
+ * https://domain/[workspaceId]/[documentId]/[filename]
  * 
  * @param fileUrl - The URL of the file from which to extract the documentId.
  * @returns The extracted documentId or an empty string if the URL is invalid.
@@ -238,7 +247,7 @@ export function getDocumentIdFromFileUrl(fileUrl: string): string {
     const pathSegments = url.pathname.split('/').filter(part => part.trim() !== '');
 
     // Assuming the documentId is always the second segment in the path
-    const documentId = pathSegments[1]; // 0: namespaceId, 1: documentId, 2: filename
+    const documentId = pathSegments[1]; // 0: workspaceId, 1: documentId, 2: filename
     return documentId;
   } catch (error) {
     console.error('Error extracting documentId from URL:', error);

--- a/namespace-notes/client/src/components/ui/upload-button.tsx
+++ b/namespace-notes/client/src/components/ui/upload-button.tsx
@@ -46,7 +46,7 @@ export default function UploadButton({
     setIsUploading(true);
 
     const formData = new FormData();
-    formData.append('namespaceId', workspaceId);
+    formData.append('workspaceId', workspaceId);
     for (let i = 0; i < selectedFiles.length; i++) {
       formData.append('files', selectedFiles[i]);
     }

--- a/namespace-notes/client/src/lib/hooks/auth-context.tsx
+++ b/namespace-notes/client/src/lib/hooks/auth-context.tsx
@@ -1,0 +1,39 @@
+'use client';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+interface AuthContextValue {
+  user: any | null;
+  defaultSpaceId?: string;
+}
+
+const AuthContext = createContext<AuthContextValue>({ user: null });
+export const useAuth = () => useContext(AuthContext);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<any | null>(null);
+
+  useEffect(() => {
+    async function fetchUser() {
+      try {
+        const res = await fetch('/api/auth/me');
+        if (res.status === 401) {
+          alert('You are not authorized');
+          return;
+        }
+        if (res.ok) {
+          const data = await res.json();
+          setUser(data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch user', err);
+      }
+    }
+    fetchUser();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, defaultSpaceId: user?.default_space_id }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/namespace-notes/server/@types/express/index.d.ts
+++ b/namespace-notes/server/@types/express/index.d.ts
@@ -1,0 +1,5 @@
+declare namespace Express {
+  interface Request {
+    user?: any;
+  }
+}

--- a/namespace-notes/server/src/controllers/contextController.ts
+++ b/namespace-notes/server/src/controllers/contextController.ts
@@ -14,6 +14,11 @@ class ContextController {
     this.fetchContext = this.fetchContext.bind(this);
   }
 
+  private getNamespaceId(req: Request, workspaceId: string): string {
+    const prefix = (req as any).user?.default_space_id;
+    return prefix ? `${prefix}:${workspaceId}` : workspaceId;
+  }
+
   /**
    * Fetch context relevant to the supplied chat messages.
    * @param req - The request object.
@@ -21,11 +26,12 @@ class ContextController {
    */
   async fetchContext(req: Request, res: Response) {
     try {
-      const { namespaceId, messages } = req.body;
+      const { workspaceId, messages } = req.body;
 
-      if (!namespaceId || !messages) {
+      if (!workspaceId || !messages) {
         return res.status(400).send({ message: "Missing required fields" });
       }
+      const namespaceId = this.getNamespaceId(req, workspaceId);
       const context =  await createPrompt(messages, namespaceId);
 
       res.status(200).send({ query: messages[messages.length-1], context});

--- a/namespace-notes/server/src/controllers/documentController.ts
+++ b/namespace-notes/server/src/controllers/documentController.ts
@@ -29,6 +29,11 @@ class DocumentsController {
     this.deleteWorkspace = this.deleteWorkspace.bind(this);
   }
 
+  private getNamespaceId(req: Request, workspaceId: string): string {
+    const prefix = (req as any).user?.default_space_id;
+    return prefix ? `${prefix}:${workspaceId}` : workspaceId;
+  }
+
   /**
    * Safe upsert with retry logic to handle rate limits.
    * @param document - The document data to be upserted.
@@ -67,7 +72,8 @@ class DocumentsController {
   async addDocuments(req: Request, res: Response) {
     upload(req, res, async (err) => {
       // This is effectively the ID of the workspace / tenant
-      let namespaceId = req.body.namespaceId;
+      let workspaceId = req.body.workspaceId;
+      let namespaceId = workspaceId ? this.getNamespaceId(req, workspaceId) : "";
       if (err instanceof multer.MulterError) {
         console.error("Multer error:", err);
         return res.status(400).json({ message: err.message });
@@ -78,11 +84,12 @@ class DocumentsController {
 
       const isNewWorkspace = req.body.newWorkspace === "true";
       if (isNewWorkspace) {
-        namespaceId = uuidv4();
-      } else if (!namespaceId) {
+        workspaceId = uuidv4();
+        namespaceId = this.getNamespaceId(req, workspaceId);
+      } else if (!workspaceId) {
         return res
           .status(400)
-          .json({ message: "Missing required field: namespaceId" });
+          .json({ message: "Missing required field: workspaceId" });
       }
 
       const filesObject = req.files as {
@@ -163,7 +170,7 @@ class DocumentsController {
       }
       res.status(200).json({
         message: "Documents added successfully",
-        namespaceId,
+        workspaceId,
         documentResponses,
       });
     });
@@ -176,7 +183,8 @@ class DocumentsController {
    * @param res - The response object.
    */
   async listFilesInNamespace(req: Request, res: Response) {
-    const namespaceId = req.params.namespaceId;
+    const workspaceId = req.params.workspaceId;
+    const namespaceId = this.getNamespaceId(req, workspaceId);
 
     try {
       let files;
@@ -199,7 +207,8 @@ class DocumentsController {
    */
   async deleteDocument(req: Request, res: Response) {
     const documentId = req.params.documentId;
-    const namespaceId = req.params.namespaceId;
+    const workspaceId = req.params.workspaceId;
+    const namespaceId = this.getNamespaceId(req, workspaceId);
 
     try {
       // Delete the document chunks from Pinecone
@@ -270,7 +279,8 @@ class DocumentsController {
    * @param res - The response object.
    */
   async deleteWorkspace(req: Request, res: Response) {
-    const namespaceId = req.params.namespaceId;
+    const workspaceId = req.params.workspaceId;
+    const namespaceId = this.getNamespaceId(req, workspaceId);
 
     try {
       // Delete the namespace from Pinecone
@@ -298,7 +308,8 @@ class DocumentsController {
    * @param res - The response object.
    */
   async serveDocument(req: Request, res: Response) {
-    const { namespaceId, documentId } = req.params;
+    const { workspaceId, documentId } = req.params;
+    const namespaceId = this.getNamespaceId(req, workspaceId);
     const fileKey = `${namespaceId}/${documentId}`;
     console.log("Serving file:", fileKey);
 

--- a/namespace-notes/server/src/index.ts
+++ b/namespace-notes/server/src/index.ts
@@ -11,6 +11,7 @@ import cors from "cors";
 import dotenv from "dotenv";
 import documentRoutes from "./routes/documentRoutes";
 import contextRoutes from "./routes/contextRoutes";
+import authRoutes from "./routes/authRoutes";
 var memwatch = require("@airbnb/node-memwatch");
 
 /** Path where uploaded files are stored. */
@@ -39,6 +40,7 @@ app.use(bodyParser.json());
 
 app.use("/api/documents", documentRoutes);
 app.use("/api/context", contextRoutes);
+app.use("/api/auth", authRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);

--- a/namespace-notes/server/src/routes/authRoutes.ts
+++ b/namespace-notes/server/src/routes/authRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+const router = Router();
+
+// Simple endpoint returning the authenticated user
+router.get('/me', (req, res) => {
+  res.json((req as any).user);
+});
+
+export default router;

--- a/namespace-notes/server/src/routes/documentRoutes.ts
+++ b/namespace-notes/server/src/routes/documentRoutes.ts
@@ -11,10 +11,10 @@ const router = Router();
  * POST /add - Upload one or more documents.
  */
 router.post("/add", (req, res) => {
-  const { namespaceId } = req.query;
+  const { workspaceId } = req.query;
 
-  if (typeof namespaceId === "string" && namespaceId.startsWith("default")) {
-    return res.status(400).json({ error: "Invalid namespaceId, you cannot edit the demo workspace" });
+  if (typeof workspaceId === "string" && workspaceId.startsWith("default")) {
+    return res.status(400).json({ error: "Invalid workspaceId, you cannot edit the demo workspace" });
   }
 
   documentController.addDocuments(req, res);
@@ -24,20 +24,20 @@ router.post("/add", (req, res) => {
  * DELETE /files/delete/:namespaceId/:documentId - Remove a specific document.
  */
 router.delete(
-  "/files/delete/:namespaceId/:documentId",
+  "/files/delete/:workspaceId/:documentId",
   documentController.deleteDocument
 );
 
 /**
  * DELETE /workspace/:namespaceId - Remove an entire workspace.
  */
-router.delete("/workspace/:namespaceId", documentController.deleteWorkspace);
+router.delete("/workspace/:workspaceId", documentController.deleteWorkspace);
 
 /** GET /files/:namespaceId - List files in a workspace. */
-router.get("/files/:namespaceId", documentController.listFilesInNamespace);
+router.get("/files/:workspaceId", documentController.listFilesInNamespace);
 /** GET /files/:namespaceId/:documentId/(*) - Serve a stored file. */
 router.get(
-  "/files/:namespaceId/:documentId/(*)",
+  "/files/:workspaceId/:documentId/(*)",
   documentController.serveDocument
 );
 


### PR DESCRIPTION
## Summary
- add `/api/auth/me` endpoint on the server
- implement namespace prefixing based on `workspaceId`
- introduce `AuthProvider` to fetch current user
- send only `workspaceId` from the client and show auth errors
- update docs for new parameter

## Testing
- `npm run lint` *(fails: files ignored or Next.js missing)*

------
https://chatgpt.com/codex/tasks/task_e_68335aa775f88321bb70c40f8a9612ed